### PR TITLE
Adding a section on static members

### DIFF
--- a/docs/fsharp/style-guide/component-design-guidelines.md
+++ b/docs/fsharp/style-guide/component-design-guidelines.md
@@ -245,6 +245,24 @@ let u = v * 10.0
 
 This guidance corresponds to general .NET guidance for these types. However, it can be additionally important in F# coding as this will allow these types to be used in conjunction with F# functions and methods with member constraints, such as List.sumBy.
 
+#### Consider having members on classes that mimic modules to follow the module name convention but use CompiledName
+
+Sometimes you define class methods that mimic module members. Since the fact that you define it on a class instead of a module is an implementation detail, this should not be exposed to f# consumers of your library. 
+
+```fsharp
+type Vector(x:float, y:float) =
+
+    member v.X = x
+    member v.Y = y
+    
+    [<CompiledName("Create")>]
+    static member create x y = Vector (x, y)
+
+let v = Vector.create 5.0 3.0
+```
+
+By using `CompiledName` you can still make sure to follow the .net name convention.
+
 #### Use method overloading for member functions, if doing so provides a simpler API
 
 Method overloading is a powerful tool for simplifying an API that may need to do multiple related things.

--- a/docs/fsharp/style-guide/component-design-guidelines.md
+++ b/docs/fsharp/style-guide/component-design-guidelines.md
@@ -247,7 +247,7 @@ This guidance corresponds to general .NET guidance for these types. However, it 
 
 #### Consider using `[<CompiledName>]` to provide a .NET-friendly name for other .NET language consumers
 
-Sometimes you may wish name something in one style for F# consumers (such as a static member in lower case), but have a different style for the name when it is compiled into an assembly. You can use the [<CompiledName>] attribute to provide a different style for code which is consuming the assembly the code is defined in.
+Sometimes you may wish name something in one style for F# consumers (such as a static member in lower case), but have a different style for the name when it is compiled into an assembly. You can use the `[<CompiledName>]` attribute to provide a different style for non F# code consuming the assembly.
 
 ```fsharp
 type Vector(x:float, y:float) =
@@ -261,7 +261,7 @@ type Vector(x:float, y:float) =
 let v = Vector.create 5.0 3.0
 ```
 
-By using `[<CompiledName>]`, you can use .NET naming conventions for consumers of the assembly the code is defined in, but use a different naming convention for F# code within the assembly.
+By using `[<CompiledName>]`, you can use .NET naming conventions for non F# consumers of the assembly.
 
 #### Use method overloading for member functions, if doing so provides a simpler API
 

--- a/docs/fsharp/style-guide/component-design-guidelines.md
+++ b/docs/fsharp/style-guide/component-design-guidelines.md
@@ -245,9 +245,9 @@ let u = v * 10.0
 
 This guidance corresponds to general .NET guidance for these types. However, it can be additionally important in F# coding as this will allow these types to be used in conjunction with F# functions and methods with member constraints, such as List.sumBy.
 
-#### Consider having members on classes that mimic modules to follow the module name convention but use CompiledName
+#### Consider using `[<CompiledName>]` to provide a .NET-friendly name for other .NET language consumers
 
-Sometimes you define class methods that mimic module members. Since the fact that you define it on a class instead of a module is an implementation detail, this should not be exposed to f# consumers of your library. 
+Sometimes you may wish name something in one style for F# consumers (such as a static member in lower case), but have a different style for the name when it is compiled into an assembly. You can use the [<CompiledName>] attribute to provide a different style for code which is consuming the assembly the code is defined in.
 
 ```fsharp
 type Vector(x:float, y:float) =
@@ -261,7 +261,7 @@ type Vector(x:float, y:float) =
 let v = Vector.create 5.0 3.0
 ```
 
-By using `CompiledName` you can still make sure to follow the .net name convention.
+By using `[<CompiledName>]`, you can use .NET naming conventions for consumers of the assembly the code is defined in, but use a different naming convention for F# code within the assembly.
 
 #### Use method overloading for member functions, if doing so provides a simpler API
 


### PR DESCRIPTION
## Summary

When you have static members, sometimes they mimic module functions. Having capitalization based on implementation details makes for naming inconsistencies when consuming API's in f#.

